### PR TITLE
Support DLT Header only messages (+ add `DltPacketSlice::message_id_and_payload`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlt_parse"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Julian Schmid <info@julianschmid.name>"]
 edition = "2021"
 description = "A library for parsing the \"Diagnostic Log and Trace\" network protocol (currently without payload interpretation)."

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ for dlt_message in SliceIterator::new(&buffer) {
     match dlt_message {
         Ok(dlt_slice) => {
             //check if the message is verbose or non verbose (non verbose messages have message ids)
-            if let Some(message_id) = dlt_slice.message_id() {
+            if let Some((message_id, non_verbose_payload)) = dlt_slice.message_id_and_payload() {
                 println!("non verbose message {:x}", message_id);
-                println!("  with payload {:?}", dlt_slice.non_verbose_payload());
+                println!("  with payload {:?}", non_verbose_payload);
             } else {
                 println!("verbose message (parsing not yet supported)");
             }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-dlt_parse = "0.5"
+dlt_parse = "0.6"
 ```
 
 Next, add this to your crate:

--- a/examples/print_dlt_file.rs
+++ b/examples/print_dlt_file.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), ReadError> {
 
         println!("{:?}", msg.storage_header);
 
-        if let Some(message_id) = msg.packet.message_id() {
+        if let Some((message_id, non_verbose_payload)) = msg.packet.message_id_and_payload() {
             if let Some(extended_header) = msg.packet.extended_header() {
                 use core::str::from_utf8;
 
@@ -46,7 +46,7 @@ fn main() -> Result<(), ReadError> {
             } else {
                 println!("non verbose message 0x{:x}", message_id);
             }
-            println!("  with payload {:?}", msg.packet.non_verbose_payload());
+            println!("  with payload {:?}", non_verbose_payload);
         } else {
             println!("verbose message (parsing not yet supported)");
         }

--- a/src/dlt_packet_slice.rs
+++ b/src/dlt_packet_slice.rs
@@ -226,7 +226,7 @@ impl<'a> DltPacketSlice<'a> {
 
     /// Returns the message id and a slice containing the payload (after the
     /// message id) if the dlt message is a non verbose message.
-    /// 
+    ///
     /// If the message is not a non verbose message or does not have enough
     /// memory for the message id `None` is returned.
     pub fn message_id_and_payload(&self) -> Option<(u32, &'a [u8])> {
@@ -656,9 +656,7 @@ mod dlt_packet_slice_tests {
                 buffer
                     .try_extend_from_slice(&0x1234_5678u32.to_be_bytes())
                     .unwrap();
-                buffer
-                    .try_extend_from_slice(&[0x10, 0x11])
-                    .unwrap();
+                buffer.try_extend_from_slice(&[0x10, 0x11]).unwrap();
 
                 // slice
                 let slice = DltPacketSlice::from_slice(&buffer).unwrap();
@@ -691,9 +689,7 @@ mod dlt_packet_slice_tests {
                 buffer
                     .try_extend_from_slice(&0x1234_5678u32.to_le_bytes())
                     .unwrap();
-                buffer
-                    .try_extend_from_slice(&[0x10, 0x11])
-                    .unwrap();
+                buffer.try_extend_from_slice(&[0x10, 0x11]).unwrap();
 
                 // slice
                 let slice = DltPacketSlice::from_slice(&buffer).unwrap();
@@ -726,9 +722,10 @@ mod dlt_packet_slice_tests {
                 buffer
                     .try_extend_from_slice(&0x1234_5678u32.to_le_bytes())
                     .unwrap();
-                
+
                 // slice
-                let slice = DltPacketSlice::from_slice(&buffer[..buffer.len() - missing_len]).unwrap();
+                let slice =
+                    DltPacketSlice::from_slice(&buffer[..buffer.len() - missing_len]).unwrap();
                 assert_eq!(None, slice.message_id());
                 assert_eq!(None, slice.message_id_and_payload());
                 assert_eq!(None, slice.non_verbose_payload());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,9 @@
 //!     match dlt_message {
 //!         Ok(dlt_slice) => {
 //!             //check if the message is verbose or non verbose (non verbose messages have message ids)
-//!             if let Some(message_id) = dlt_slice.message_id() {
+//!             if let Some((message_id, non_verbose_payload)) = dlt_slice.message_id_and_payload() {
 //!                 println!("non verbose message {:x}", message_id);
-//!                 println!("  with payload {:?}", dlt_slice.non_verbose_payload());
+//!                 println!("  with payload {:?}", non_verbose_payload);
 //!             } else {
 //!                 println!("verbose message (parsing not yet supported)");
 //!             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! dlt_parse = "0.5"
+//! dlt_parse = "0.6"
 //! ```
 //!
 //! Next, add this to your crate:

--- a/src/proptest_generators/mod.rs
+++ b/src/proptest_generators/mod.rs
@@ -22,7 +22,7 @@ prop_compose! {
 
 prop_compose! {
     pub fn dlt_header_with_payload_any()(
-        payload_length in 4usize..TEST_MAX_PAYLOAD_SIZE
+        payload_length in 0usize..TEST_MAX_PAYLOAD_SIZE
     )(
         is_big_endian in any::<bool>(),
         message_counter in any::<u8>(),

--- a/src/storage/dlt_storage_reader.rs
+++ b/src/storage/dlt_storage_reader.rs
@@ -2,8 +2,8 @@ use std::io::{BufRead, Read};
 use std::vec::Vec;
 
 use crate::error::{DltMessageLengthTooSmallError, ReadError, UnsupportedDltVersionError};
-use crate::{storage::StorageHeader, DltPacketSlice};
 use crate::MAX_VERSION;
+use crate::{storage::StorageHeader, DltPacketSlice};
 
 use super::StorageSlice;
 


### PR DESCRIPTION
- `DltPacketSlice::from_slice` & `storage::DltStorageReader` now allow DLT packets that only consist of an header.
- Added new method `DltPacketSlice::message_id_and_payload` that allows to get the message id together with the non verbose payload.
- `DltPacketSlice ::non_verbose_payload` return type changed from `&[u8]` to `Option<&[u8]>` (only return `Some` if the packet is non_verbose and the length is big enough.